### PR TITLE
Extract pubsub-devpub from devpub example of blocks-gcs-proxy 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+sudo: false
+language: go
+go:
+  - 1.6.3
+addons:
+  apt:
+    sources:
+      - sourceline: 'ppa:masterminds/glide'
+    packages:
+      - glide
+before_install:
+  - test -d $GOPATH/bin || mkdir -p $GOPATH/bin
+  - make checksetup
+install:
+  ## Install dependencies
+  - glide install
+before_script:
+  - make check
+script:
+  - go test

--- a/Makefile
+++ b/Makefile
@@ -33,10 +33,10 @@ build:
 	done
 
 release: build
-	ghr -u groovenauts -r blocks-gcs-proxy --replace --draft ${VERSION} pkg
+	ghr -u groovenauts -r pubsub-devpub --replace --draft ${VERSION} pkg
 
 prerelease: build
-	ghr -u groovenauts -r blocks-gcs-proxy --replace --draft --prerelease ${VERSION} pkg
+	ghr -u groovenauts -r pubsub-devpub --replace --draft --prerelease ${VERSION} pkg
 
 version:
 	echo ${VERSION}

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,12 @@ build:
 		gox -output="${PKGDIR}/{{.Dir}}_{{.OS}}_{{.Arch}}" -os="$$x" -arch="${ARCH}" ; \
 	done
 
+release: build
+	ghr -u groovenauts -r blocks-gcs-proxy --replace --draft ${VERSION} pkg
+
+prerelease: build
+	ghr -u groovenauts -r blocks-gcs-proxy --replace --draft --prerelease ${VERSION} pkg
+
 version:
 	echo ${VERSION}
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ export PATH=$PATH:$GOPATH/bin
 ```bash
 $ ./pubsub-devpub --help
 NAME:
-   blocks-gcs-proxy - github.com/groovenauts/blocks-gcs-proxy
+   pubsub-devpub - github.com/groovenauts/pubsub-devpub
 
 USAGE:
    pubsub-devpub [global options] command [command options] [arguments...]

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 {"topic":"projects/proj-dummy-999/topics/devpub-target-topic","attributes":{"download_files":"[\"gs://test-bucket1/path/to/file000003\"]"}}
 ```
 
-Now `pubsub-debpub` supports [JSON Lines](http://jsonlines.org/) only.
+Now `pubsub-devpub` supports [JSON Lines](http://jsonlines.org/) only.
 
 
 ## Install

--- a/README.md
+++ b/README.md
@@ -1,0 +1,66 @@
+# pubsub-devpub
+
+`pubsub-devpub` helps you to publish lots of messages to `Google Cloud Pubsub` topics.
+`pubsub-devpub` works concurrently with `--number` option.
+`pubsub-devpub` publishes messages for each line of given file like this:
+
+```jsonl
+{"topic":"projects/proj-dummy-999/topics/devpub-target-topic","attributes":{"download_files":"[\"gs://test-bucket1/path/to/file000001\"]"}}
+{"topic":"projects/proj-dummy-999/topics/devpub-target-topic","attributes":{"download_files":"[\"gs://test-bucket1/path/to/file000002\"]"}}
+{"topic":"projects/proj-dummy-999/topics/devpub-target-topic","attributes":{"download_files":"[\"gs://test-bucket1/path/to/file000003\"]"}}
+```
+
+Now `pubsub-debpub` supports [JSON Lines](http://jsonlines.org/) only.
+
+
+## Install
+
+To install cli, simply run:
+```
+go get github.com/groovenauts/pubsub-devsub
+```
+
+Make sure your PATH includes the $GOPATH/bin directory so your commands can be easily used:
+
+```
+export PATH=$PATH:$GOPATH/bin
+```
+
+## Usage
+
+```bash
+$ ./pubsub-devpub --help
+NAME:
+   blocks-gcs-proxy - github.com/groovenauts/blocks-gcs-proxy
+
+USAGE:
+   pubsub-devpub [global options] command [command options] [arguments...]
+
+VERSION:
+   0.0.1
+
+COMMANDS:
+     help, h  Shows a list of commands or help for one command
+
+GLOBAL OPTIONS:
+   --filepath value, -f value  Messages filepath (.jsonl JSON Lines format)
+   --number value, -n value    Number of go routine to publish (default: 10)
+   --loglevel value, -l value  Log level: debug info warn error fatal panic
+   --help, -h                  show help
+   --version, -v               print the version
+```
+
+## How to build
+
+```
+$ make setup
+$ make check
+$ make build
+```
+
+
+## How to release
+
+```
+$ make release
+```

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # pubsub-devpub
 
+[![Build Status](https://secure.travis-ci.org/groovenauts/pubsub-devpub.png)](https://travis-ci.org/groovenauts/pubsub-devpub)
+
+
 `pubsub-devpub` helps you to publish lots of messages to `Google Cloud Pubsub` topics.
 `pubsub-devpub` works concurrently with `--number` option.
 `pubsub-devpub` publishes messages for each line of given file like this:

--- a/cli.go
+++ b/cli.go
@@ -8,8 +8,8 @@ import (
 	"golang.org/x/net/context"
 	"golang.org/x/oauth2/google"
 
-	pubsub "google.golang.org/api/pubsub/v1"
 	log "github.com/Sirupsen/logrus"
+	pubsub "google.golang.org/api/pubsub/v1"
 )
 
 func main() {
@@ -24,7 +24,7 @@ func main() {
 			Usage: "Messages filepath (.jsonl JSON Lines format)",
 		},
 		cli.IntFlag{
-			Name: "number, n",
+			Name:  "number, n",
 			Usage: "Number of go routine to publish",
 			Value: 10,
 		},
@@ -63,13 +63,13 @@ func run(c *cli.Context) error {
 		}
 		workers = append(workers, worker)
 	}
-	
+
 	workers.process(c.String("filepath"))
 
 	return nil
 }
 
-func NewPubsubService() (*pubsub.Service, error){
+func NewPubsubService() (*pubsub.Service, error) {
 	ctx := context.Background()
 
 	// https://github.com/google/google-api-go-client#application-default-credentials-example

--- a/cli.go
+++ b/cli.go
@@ -14,8 +14,8 @@ import (
 
 func main() {
 	app := cli.NewApp()
-	app.Name = "blocks-gcs-proxy"
-	app.Usage = "github.com/groovenauts/blocks-gcs-proxy"
+	app.Name = "pubsub-devpub"
+	app.Usage = "github.com/groovenauts/pubsub-devpub"
 	app.Version = VERSION
 
 	app.Flags = []cli.Flag{

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 156f52ad2ee657b27d34fa30d662b7f1789eb9dbb1a61c039d5b7fe3d4d4c3d1
-updated: 2017-04-12T13:29:07.531621033+09:00
+hash: 81c2400ed61ae1ad48ef45900f66ce6e38e810c80c85863c950ce59604c4c0fb
+updated: 2017-04-18T12:01:21.401603005+09:00
 imports:
 - name: cloud.google.com/go
   version: 81b7822b1e798e8f17bf64b59512a5be4097e966
@@ -70,4 +70,8 @@ imports:
   - stats
   - tap
   - transport
-testImports: []
+testImports:
+- name: github.com/stretchr/testify
+  version: 4d4bfba8f1d1027c4fdbe371823030df51419987
+  subpackages:
+  - assert

--- a/glide.yaml
+++ b/glide.yaml
@@ -11,3 +11,7 @@ import:
 - package: google.golang.org/api
   subpackages:
   - pubsub/v1
+testImport:
+- package: github.com/stretchr/testify
+  subpackages:
+  - assert

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,4 +1,4 @@
-package: github.com/groovenauts/blocks-gcs-proxy/examples/devpub
+package: github.com/groovenauts/pubsub-devpub
 import:
 - package: github.com/Sirupsen/logrus
 - package: github.com/urfave/cli

--- a/worker.go
+++ b/worker.go
@@ -10,14 +10,14 @@ import (
 )
 
 type Message struct {
-	Topic string `json:"topic"`
-	Data string `json:"data,omitempty"`
+	Topic      string            `json:"topic"`
+	Data       string            `json:"data,omitempty"`
 	Attributes map[string]string `json:"attributes,omitempty"`
 }
 
 type Worker struct {
 	service *pubsub.Service
-	lines chan string
+	lines   chan string
 	done    bool
 	error   error
 }
@@ -72,7 +72,7 @@ func (w *Worker) process(line string) error {
 		Messages: []*pubsub.PubsubMessage{
 			&pubsub.PubsubMessage{
 				Attributes: msg.Attributes,
-				Data: base64.StdEncoding.EncodeToString([]byte(msg.Data)),
+				Data:       base64.StdEncoding.EncodeToString([]byte(msg.Data)),
 			},
 		},
 	})
@@ -88,6 +88,6 @@ func (w *Worker) process(line string) error {
 
 	flds["MessageIds"] = res.MessageIds
 	log.WithFields(flds).Infoln("Publish successfully")
-	
+
 	return nil
 }

--- a/workers_test.go
+++ b/workers_test.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWorkersDone(t *testing.T) {
+	w1 := &Worker{}
+	w2 := &Worker{}
+	w3 := &Worker{}
+
+	ws := &Workers{w1, w2, w3}
+	assert.Equal(t, false, ws.done())
+
+	w1.done = true
+	assert.Equal(t, false, ws.done())
+	w2.done = true
+	assert.Equal(t, false, ws.done())
+	w3.done = true
+	assert.Equal(t, true, ws.done())
+}
+
+func TestWorkersError(t *testing.T) {
+	w1 := &Worker{}
+	w2 := &Worker{}
+	w3 := &Worker{}
+
+	ws := &Workers{w1, w2, w3}
+	assert.NoError(t, ws.error())
+
+	w1.error = fmt.Errorf("foo")
+	assert.Error(t, ws.error())
+	assert.Equal(t, "foo", ws.error().Error())
+
+	w2.error = fmt.Errorf("bar")
+	assert.Error(t, ws.error())
+	assert.Equal(t, "foo\nbar", ws.error().Error())
+}


### PR DESCRIPTION
Extract pubsub-devpub from [devpub example of blocks-gcs-proxy](https://github.com/groovenauts/blocks-gcs-proxy/tree/bd3ccf03ba900098b605010e15d7a85a5b862c83/examples/devpub) to be able to publish test data without blocks-concurrent-batch.

See [README.md](https://github.com/groovenauts/pubsub-devpub/blob/features/initial_setup/README.md) for more detail